### PR TITLE
Synchronous logic to basic threaded logic

### DIFF
--- a/assignment/.gitignore
+++ b/assignment/.gitignore
@@ -1,1 +1,2 @@
 venv/
+__pycache__/

--- a/assignment/app.py
+++ b/assignment/app.py
@@ -41,19 +41,29 @@ def get_html(link: str):
             return (res.content.decode("utf-8"), None)
         else:
             return (None, Exception("No html!"))
-    except:
+    except Exception as e:
         return (None, Exception("Error!"))
 
 
 # Writes to given title to file synchronously
 def write_to_file(sitename: str, title: str):
     # TODO : write the title to a file in the /out directory named : <sitename>.txt
-    pass
+    # pass
+
+    base_path = os.getcwd()
+    output_path = base_path + "/out/sync3"
+
+    if not os.path.exists(output_path):
+        os.makedirs(output_path)
+
+    with open(output_path + f"/{sitename}.txt", "w") as outfile:
+        outfile.write(title)
 
 
 # TODO : convert to async
 # scrape the given link synchronously
 def scrape(website: dict):
+    os.system("") # enables ANSI escape sequences in terminal
     try:
         (html, err) = get_html(website[DOMAIN_NAME])
 
@@ -95,6 +105,13 @@ def main():
     # TODO : convert to async
     # TODO : read csv of links in dictionary format
     # TODO : call the scrape function on them one by one
+
+    csvgen = (row for row in open(dataset_path, "r"))
+    next(csvgen) # to skip header row
+
+    for row in csvgen:
+        site, domain_name = row.strip().split(',')
+        scrape({ SITE: site, DOMAIN_NAME: domain_name })
 
 
 main()

--- a/assignment/app.py
+++ b/assignment/app.py
@@ -72,7 +72,7 @@ def write_to_file(sitename: str, title: str):
 # TODO : convert to async
 # scrape the given link synchronously
 def scrape(website: dict):
-    os.system("") # enables ANSI escape sequences in terminal
+
     try:
         (html, err) = get_html(website[DOMAIN_NAME])
 
@@ -163,6 +163,7 @@ def main():
 
 
 if __name__ == "__main__":
+    os.system("") # enables ANSI escape sequences in terminal
     start = time.time()
     main()
     end = time.time()

--- a/assignment/app.py
+++ b/assignment/app.py
@@ -56,7 +56,7 @@ def write_to_file(sitename: str, title: str):
     # pass
 
     base_path = os.getcwd()
-    output_path = base_path + "/out/sync3"
+    output_path = base_path + "/out/sync6"
 
     if not os.path.exists(output_path):
         os.makedirs(output_path)
@@ -122,4 +122,7 @@ def main():
         scrape({ SITE: site, DOMAIN_NAME: domain_name })
 
 
+start = time.time()
 main()
+end = time.time()
+print(f"Completed tasks in {end - start} seconds")

--- a/assignment/app.py
+++ b/assignment/app.py
@@ -122,7 +122,8 @@ def main():
         scrape({ SITE: site, DOMAIN_NAME: domain_name })
 
 
-start = time.time()
-main()
-end = time.time()
-print(f"Completed tasks in {end - start} seconds")
+if __name__ == "__main__":
+    start = time.time()
+    main()
+    end = time.time()
+    print(f"Completed tasks in {end - start} seconds")

--- a/assignment/app.py
+++ b/assignment/app.py
@@ -60,7 +60,7 @@ def write_to_file(sitename: str, title: str):
     # pass
 
     base_path = os.getcwd()
-    output_path = base_path + "/out/sync9"
+    output_path = base_path + "/out/"
 
     if not os.path.exists(output_path):
         os.makedirs(output_path)
@@ -80,27 +80,43 @@ def scrape(website: dict):
             msg = website[SITE] + " : " + "FAILED!"
             # HINT : remember that -> writing to file is blocking
             # TODO : convert to async/threading?
+            """
             write_to_file(website[SITE], msg)
             # print(website[SITE], " : ", website[DOMAIN_NAME], "error!")
             print(website[SITE], " : ", website[DOMAIN_NAME], "\033[1;31merror!\033[m")
             return
+            """
+            raise Exception
+
 
         soup = BeautifulSoup(html, "html5lib")
-
         title = website[SITE] + " : TITLE -> " + get_title(soup)
+        msg = title
+        status_msg = "\033[1;32msuccess!\033[m"
 
+        """
         # TODO : convert to async/threading?
         write_to_file(website[SITE], title)
         # print(website[SITE], " : ", website[DOMAIN_NAME], "success!")
         print(website[SITE], " : ", website[DOMAIN_NAME], "\033[1;32msuccess!\033[m")
+        """
+
 
     except Exception as err:
         msg = website[SITE] + " : " + "FAILED!"
+        status_msg = "\033[1;31merror!\033[m"
         # HINT : remember that -> writing to file is blocking
         # TODO : convert to async/threading?
+        """
         write_to_file(website[SITE], msg)
         # print(website[SITE], " : ", website[DOMAIN_NAME], "error!")
         print(website[SITE], " : ", website[DOMAIN_NAME], "\033[1;31merror!\033[m")
+        """
+
+    finally:
+        write_to_file(website[SITE], msg)
+        print(website[SITE], " : ", website[DOMAIN_NAME], status_msg)
+
 
 
 # TODO : convert to async
@@ -127,30 +143,6 @@ def main():
     csvgen = (row for row in open(dataset_path, "r"))
     next(csvgen) # to skip header row
 
-    """
-    threads = []
-
-    for row in csvgen:
-        site, domain_name = row.strip().split(',')
-        thread = threading.Thread(
-            target = scrape,
-            args = ({
-                SITE: site,
-                DOMAIN_NAME: domain_name,
-            }, ),
-            # `args` expects a tuple of arguments
-        )
-
-        thread.start()
-        threads.append(thread)
-
-        # scrape({ SITE: site, DOMAIN_NAME: domain_name })
-
-    for thread in threads:
-        thread.join()
-        # This makes the main thread
-        # wait for `thread` to finish.
-    """
     with ThreadPoolExecutor(max_workers = n_threads) as executor:
 
         for row in csvgen:

--- a/assignment/app.py
+++ b/assignment/app.py
@@ -3,6 +3,8 @@ from bs4 import BeautifulSoup
 import os, csv, time
 
 import threading
+from concurrent.futures import ThreadPoolExecutor
+
 
 """
 Assignment Instructions : 
@@ -58,7 +60,7 @@ def write_to_file(sitename: str, title: str):
     # pass
 
     base_path = os.getcwd()
-    output_path = base_path + "/out/sync6"
+    output_path = base_path + "/out/sync7"
 
     if not os.path.exists(output_path):
         os.makedirs(output_path)
@@ -119,28 +121,38 @@ def main():
     csvgen = (row for row in open(dataset_path, "r"))
     next(csvgen) # to skip header row
 
+    """
     threads = []
 
     for row in csvgen:
-		site, domain_name = row.strip().split(',')
-		thread = threading.Thread(
-			target = scrape,
-			args = ({
-				SITE: site,
-				DOMAIN_NAME: domain_name,
-			}, ),
-			# `args` expects a tuple of arguments
-		)
+        site, domain_name = row.strip().split(',')
+        thread = threading.Thread(
+            target = scrape,
+            args = ({
+                SITE: site,
+                DOMAIN_NAME: domain_name,
+            }, ),
+            # `args` expects a tuple of arguments
+        )
 
-		thread.start()
-		threads.append(thread)
+        thread.start()
+        threads.append(thread)
 
         # scrape({ SITE: site, DOMAIN_NAME: domain_name })
 
     for thread in threads:
-		thread.join()
-		# This makes the main thread
-		# wait for `thread` to finish.
+        thread.join()
+        # This makes the main thread
+        # wait for `thread` to finish.
+    """
+    with ThreadPoolExecutor(max_workers = 8) as executor:
+
+        for row in csvgen:
+            site, domain_name = row.strip().split(',')
+            executor.submit(scrape, {
+                    SITE: site,
+                    DOMAIN_NAME: domain_name,
+            })
 
 
 

--- a/assignment/app.py
+++ b/assignment/app.py
@@ -72,7 +72,8 @@ def scrape(website: dict):
             # HINT : remember that -> writing to file is blocking
             # TODO : convert to async/threading?
             write_to_file(website[SITE], msg)
-            print(website[SITE], " : ", website[DOMAIN_NAME], "error!")
+            # print(website[SITE], " : ", website[DOMAIN_NAME], "error!")
+            print(website[SITE], " : ", website[DOMAIN_NAME], "\033[1;31merror!\033[m")
             return
 
         soup = BeautifulSoup(html, "html5lib")
@@ -81,14 +82,16 @@ def scrape(website: dict):
 
         # TODO : convert to async/threading?
         write_to_file(website[SITE], title)
-        print(website[SITE], " : ", website[DOMAIN_NAME], "success!")
+        # print(website[SITE], " : ", website[DOMAIN_NAME], "success!")
+        print(website[SITE], " : ", website[DOMAIN_NAME], "\033[1;32msuccess!\033[m")
 
     except Exception as err:
         msg = website[SITE] + " : " + "FAILED!"
         # HINT : remember that -> writing to file is blocking
         # TODO : convert to async/threading?
         write_to_file(website[SITE], msg)
-        print(website[SITE], " : ", website[DOMAIN_NAME], "error!")
+        # print(website[SITE], " : ", website[DOMAIN_NAME], "error!")
+        print(website[SITE], " : ", website[DOMAIN_NAME], "\033[1;31merror!\033[m")
 
 
 # TODO : convert to async

--- a/assignment/app.py
+++ b/assignment/app.py
@@ -27,6 +27,11 @@ def get_title(page: BeautifulSoup):
     if title is not None:
         return title.get_text()
     else:
+        # For some websites (e.g. Twitter): <link title="..." ... />
+        for i in page.find_all("link"):
+            if i.has_attr("title"):
+                return i["title"]
+
         raise Exception("nah")
 
 

--- a/assignment/app.py
+++ b/assignment/app.py
@@ -44,7 +44,7 @@ def get_title(page: BeautifulSoup):
 def get_html(link: str):
     # get page
     try:
-        res = requests.get("https://" + link)
+        res = requests.get("https://" + link, timeout = 3)
 
         if res is not None:
             return (res.content.decode("utf-8"), None)
@@ -60,7 +60,7 @@ def write_to_file(sitename: str, title: str):
     # pass
 
     base_path = os.getcwd()
-    output_path = base_path + "/out/sync8"
+    output_path = base_path + "/out/sync9"
 
     if not os.path.exists(output_path):
         os.makedirs(output_path)

--- a/assignment/app.py
+++ b/assignment/app.py
@@ -60,7 +60,7 @@ def write_to_file(sitename: str, title: str):
     # pass
 
     base_path = os.getcwd()
-    output_path = base_path + "/out/sync7"
+    output_path = base_path + "/out/sync8"
 
     if not os.path.exists(output_path):
         os.makedirs(output_path)
@@ -118,6 +118,12 @@ def main():
     # TODO : read csv of links in dictionary format
     # TODO : call the scrape function on them one by one
 
+    # Get number of urls -> number of threads
+    with open(dataset_path, "r") as f:
+        _ = next(f) # skip header row
+        n_threads = sum(1 for _ in f)
+
+
     csvgen = (row for row in open(dataset_path, "r"))
     next(csvgen) # to skip header row
 
@@ -145,7 +151,7 @@ def main():
         # This makes the main thread
         # wait for `thread` to finish.
     """
-    with ThreadPoolExecutor(max_workers = 8) as executor:
+    with ThreadPoolExecutor(max_workers = n_threads) as executor:
 
         for row in csvgen:
             site, domain_name = row.strip().split(',')

--- a/assignment/app.py
+++ b/assignment/app.py
@@ -2,6 +2,8 @@ import requests
 from bs4 import BeautifulSoup
 import os, csv, time
 
+import threading
+
 """
 Assignment Instructions : 
 
@@ -117,9 +119,29 @@ def main():
     csvgen = (row for row in open(dataset_path, "r"))
     next(csvgen) # to skip header row
 
+    threads = []
+
     for row in csvgen:
-        site, domain_name = row.strip().split(',')
-        scrape({ SITE: site, DOMAIN_NAME: domain_name })
+		site, domain_name = row.strip().split(',')
+		thread = threading.Thread(
+			target = scrape,
+			args = ({
+				SITE: site,
+				DOMAIN_NAME: domain_name,
+			}, ),
+			# `args` expects a tuple of arguments
+		)
+
+		thread.start()
+		threads.append(thread)
+
+        # scrape({ SITE: site, DOMAIN_NAME: domain_name })
+
+    for thread in threads:
+		thread.join()
+		# This makes the main thread
+		# wait for `thread` to finish.
+
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR makes changes to convert the original synchronous logic to a basic concurrent one using the built-in `threading` library. It makes each GET request on a separate thread using `concurrent.futures.ThreadPoolExecutor` and also adds a timeout of 3 seconds to the `requests.get` call. The speedup achieved is substantial, even without rigourous testing - on single runs, the synchronous logic completed in ~118.14 seconds, while this threaded logic completes in ~8.57s.